### PR TITLE
docs(readme): fix example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ naddr -d <identifier> -p <pubkey> -k <kind> [-r <relay>]
 ### Example
 
 ```bash
-naddr -i myprofile -p 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d -k 1234 -r wss://example.com
+naddr -d myprofile -p 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d -k 1234 -r wss://example.com
 ```
 
 This command will output the encoded NAddr string.


### PR DESCRIPTION
Fixes the `-d` arg in the example invocation in the readme file.

Before:
```
./bin/naddr.js -i myprofile -p 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d -k 1234 -r wss://example.com
error: required option '-d, --dtag <string>' not specified
```

After:
```
./bin/naddr.js -d myprofile -p 3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d -k 1234 -r wss://example.com
naddr1qqyk67tswfhkv6tvv5pzqwlsccluhy6xxsr6l9a9uhhxf75g85g8a709tprjcn4e42h053vaqvzqqqqy6gq3zamnwvaz7tm90psk6urvv5hxxmmdpmcy2t
```